### PR TITLE
Cluster compatibility

### DIFF
--- a/Snake_Dropseq.py
+++ b/Snake_Dropseq.py
@@ -220,10 +220,10 @@ rule link_primary_annotation:
         fasta = PATH_REFERENCE_PRIMARY
     output:
         gtf   = LINK_GTF_PRIMARY,
-        fasta = LINK_REFERENCE_PRIMARY,
+        fasta = LINK_REFERENCE_PRIMARY
     params:
-        threads=1,
-        mem='4G'
+        threads = config['execution']['rules']['link_primary_annotation']['threads'],
+        mem     = config['execution']['rules']['link_primary_annotation']['memory']
     message:
         """
             Linking primary reference files:
@@ -250,8 +250,8 @@ if GENOME_SECONDARY_IND:
         output:
             outfile = PATH_REFERENCE_MIX
         params:
-            threads=1,
-            mem='4G',
+            threads = config['execution']['rules']['combine_reference']['threads'],
+            mem     = config['execution']['rules']['combine_reference']['memory'],
             genome_name_primary   = GENOME_NAME_PRIMARY,
             genome_name_secondary = GENOME_NAME_SECONDARY,
             perl = SOFTWARE['perl']['executable'],
@@ -279,8 +279,8 @@ rule make_star_reference:
     params:
         outdir  = os.path.join(PATH_ANNOTATION, '{genome}','STAR_INDEX'),
         star    = SOFTWARE['star']['executable'],
-        threads = 8,
-        mem     = '40G'
+        threads = config['execution']['rules']['make_star_reference']['threads'],
+        mem     = config['execution']['rules']['make_star_reference']['memory']
     log:
         os.path.join(PATH_LOG, '{genome}.make_star_reference.log')
     message:"""
@@ -304,8 +304,8 @@ if GENOME_SECONDARY_IND:
         output:
             outfile = PATH_GTF_MIX
         params:
-            threads=1,
-            mem='4G',
+            threads = config['execution']['rules']['combine_gtf']['threads'],
+            mem     = config['execution']['rules']['combine_gtf']['memory'],
             genome_name_primary   = GENOME_NAME_PRIMARY,
             genome_name_secondary = GENOME_NAME_SECONDARY,
             perl = SOFTWARE['perl']['executable'],
@@ -330,11 +330,11 @@ rule fasta_dict:
     output:
         outfile = os.path.join(PATH_ANNOTATION, '{genome}', '{genome}.dict')
     params:
-        picard   = SOFTWARE['picard']['executable'],
-        java     = SOFTWARE['java']['executable'],
-        threads  = 1,
-        mem      = '2G',
-        tempdir  = TEMPDIR,
+        picard  = SOFTWARE['picard']['executable'],
+        java    = SOFTWARE['java']['executable'],
+        threads = config['execution']['rules']['fasta_dict']['threads'],
+        mem     = config['execution']['rules']['fasta_dict']['memory'],
+        tempdir = TEMPDIR,
         app_name = 'CreateSequenceDictionary'
     log:
         log = os.path.join(PATH_LOG, '{genome}.fasta_dict.log')
@@ -364,8 +364,8 @@ rule change_gtf_id:
     output:
         outfile = os.path.join(PATH_ANNOTATION, '{genome}', '{genome}.gene_id.gtf')
     params:
-        threads = 1,
-        mem     = '4G',
+        threads = config['execution']['rules']['change_gtf_id']['threads'],
+        mem     = config['execution']['rules']['change_gtf_id']['memory'],
         script  = PATH_SCRIPT,
         Rscript = PATH_RSCRIPT
     message:
@@ -386,8 +386,8 @@ rule gtf_to_refflat:
     output:
         outfile = os.path.join(PATH_ANNOTATION, '{genome}', '{genome}.refFlat')
     params:
-        threads   = 1,
-        mem       = '30G',
+        threads   = config['execution']['rules']['gtf_to_refflat']['threads'],
+        mem       = config['execution']['rules']['gtf_to_refflat']['memory'],
         java      = SOFTWARE['java']['executable'] ,
         droptools = SOFTWARE['droptools']['executable'],
         tempdir   = TEMPDIR,
@@ -427,12 +427,12 @@ rule merge_fastq_to_bam:
     output:
         outfile = os.path.join(PATH_MAPPED, "{name}", "{name}.fastq.bam")
     params:
-        name     = '{name}',
-        picard   = SOFTWARE['picard']['executable'],
-        java     = SOFTWARE['java']['executable'],
-        threads  = 1,
-        mem      = '2G',
-        tempdir  = TEMPDIR,
+        name    = '{name}',
+        picard  = SOFTWARE['picard']['executable'],
+        java    = SOFTWARE['java']['executable'],
+        threads = config['execution']['rules']['merge_fastq_to_bam']['threads'],
+        mem     = config['execution']['rules']['merge_fastq_to_bam']['memory'],
+        tempdir = TEMPDIR,
         app_name = 'FastqToSam'
     log:
         log = os.path.join(PATH_LOG, '{name}.merge_fastq_to_bam.log')
@@ -469,15 +469,14 @@ rule tag_cells:
         java       = SOFTWARE['java']['executable'],
         app_name   = 'TagBamWithReadSequenceExtended',
         name       = '{name}',
-        threads    = 8,
-        mem        = '35G',
+        threads   = config['execution']['rules']['tag_cells']['threads'],
+        mem       = config['execution']['rules']['tag_cells']['memory'],
         tempdir    = TEMPDIR,
         base_qual  = 10,
         barcoded_read = 1,
         discard_read  = 'false'
     log:
        log = os.path.join(PATH_LOG, "{name}.{genome}.tag_cells.log")
-
     run:
         tool = java_tool(params.java, params.threads, params.mem, params.tempdir, params.droptools, params.app_name)
         
@@ -511,8 +510,8 @@ rule tag_molecules:
         java      = SOFTWARE['java']['executable'],
         app_name  = 'TagBamWithReadSequenceExtended',
         name      = '{name}',
-        threads   = 8,
-        mem       = '35G',
+        threads   = config['execution']['rules']['tag_molecules']['threads'],
+        mem       = config['execution']['rules']['tag_molecules']['memory'],
         tempdir   = TEMPDIR,
         base_qual = 10,
         barcoded_read = 1,
@@ -550,9 +549,9 @@ rule filter_bam:
         droptools = SOFTWARE['droptools']['executable'],
         java      = SOFTWARE['java']['executable'],
         app_name  = 'FilterBAM',
-        threads   = 1,
-        mem       = '10G',
-        tempdir   = TEMPDIR,
+        threads   = config['execution']['rules']['filter_bam']['threads'],
+        mem       = config['execution']['rules']['filter_bam']['memory'],
+        tempdir   = TEMPDIR
     log:
        log = os.path.join(PATH_LOG, "{name}.{genome}.filter_bam.log")
 
@@ -577,8 +576,8 @@ rule trim_starting_sequence:
         droptools  = SOFTWARE['droptools']['executable'],
         java       = SOFTWARE['java']['executable'],
         app_name   = 'TrimStartingSequence',
-        threads    = 1,
-        mem        = '10G',
+        threads    = config['execution']['rules']['trim_starting_sequence']['threads'],
+        mem        = config['execution']['rules']['trim_starting_sequence']['memory'],
         tempdir    = TEMPDIR,
         summary    = os.path.join(PATH_MAPPED, "{name}", "{genome}","adapter_trimming_report.txt"),
         mismatches = 1,
@@ -611,8 +610,8 @@ rule trim_polya:
         droptools  = SOFTWARE['droptools']['executable'],
         java       = SOFTWARE['java']['executable'],
         app_name   = 'PolyATrimmer',
-        threads    = 1,
-        mem        = '10G',
+        threads    = config['execution']['rules']['trim_polya']['threads'],
+        mem        = config['execution']['rules']['trim_polya']['memory'],
         tempdir    = TEMPDIR,
         summary    = os.path.join(PATH_MAPPED, "{name}", "{genome}","polyA_trimming_report.txt"),
         mismatches = 0,
@@ -642,8 +641,8 @@ rule sam_to_fastq:
         picard     = SOFTWARE['picard']['executable'],
         java       = SOFTWARE['java']['executable'],
         app_name   = 'SamToFastq',
-        threads    = 1,
-        mem        = '10G',
+        threads    = config['execution']['rules']['sam_to_fastq']['threads'],
+        mem        = config['execution']['rules']['sam_to_fastq']['memory'],
         tempdir    = TEMPDIR
     log:
        log = os.path.join(PATH_LOG, "{name}.{genome}.SamToFastq.log")
@@ -669,8 +668,8 @@ rule map_star:
         star       = SOFTWARE['star']['executable'],
         genome     = os.path.join(PATH_ANNOTATION, '{genome}','STAR_INDEX'),
         outpath    = os.path.join(PATH_MAPPED, "{name}", "{genome}"),
-        threads    = 4,
-        mem        = '32G',
+        threads    = config['execution']['rules']['map_star']['threads'],
+        mem        = config['execution']['rules']['map_star']['memory'],
         tempdir    = TEMPDIR,
     log:
        log = os.path.join(PATH_LOG, "{name}.{genome}.star.log")
@@ -689,8 +688,8 @@ rule sort_aligned:
         picard     = SOFTWARE['picard']['executable'],
         java       = SOFTWARE['java']['executable'],
         app_name   = 'SortSam',
-        threads    = 1,
-        mem        = '5G',
+        threads    = config['execution']['rules']['sort_aligned']['threads'],
+        mem        = config['execution']['rules']['sort_aligned']['memory'],
         tempdir    = TEMPDIR
     log:
        log = os.path.join(PATH_LOG, "{name}.{genome}.sort_aligned.log")
@@ -720,8 +719,8 @@ rule merge_bam:
         picard     = SOFTWARE['picard']['executable'],
         java       = SOFTWARE['java']['executable'],
         app_name   = 'MergeBamAlignment',
-        threads    = 1,
-        mem        = '5G',
+        threads    = config['execution']['rules']['merge_bam']['threads'],
+        mem        = config['execution']['rules']['merge_bam']['memory'],
         tempdir    = TEMPDIR
     log:
        log = os.path.join(PATH_LOG, "{name}.{genome}.merge_bam.log")
@@ -751,8 +750,8 @@ rule tag_with_gene_exon:
         droptools  = SOFTWARE['droptools']['executable'],
         java       = SOFTWARE['java']['executable'],
         app_name   = 'TagReadWithGeneExon',
-        threads    = 1,
-        mem        = '5G',
+        threads    = config['execution']['rules']['tag_with_gene_exon']['threads'],
+        mem        = config['execution']['rules']['tag_with_gene_exon']['memory'],
         tempdir    = TEMPDIR
     log:
        log = os.path.join(PATH_LOG, "{name}.{genome}.tag_with_gene_exon.log")
@@ -780,8 +779,8 @@ rule extract_read_statistics:
         outfile = os.path.join(PATH_MAPPED, "{name}", "{genome}",'{name}_{genome}_ReadStatistics.txt')
     params:
         outname  = "{name}_{genome}",
-        threads  = 1,
-        mem      = '8G',
+        threads  = config['execution']['rules']['extract_read_statistics']['threads'],
+        mem      = config['execution']['rules']['extract_read_statistics']['memory'],
         script   = PATH_SCRIPT,
         Rscript  = PATH_RSCRIPT
     message: """
@@ -805,8 +804,8 @@ rule bam_tag_histogram:
     params:
         outdir    = os.path.join(PATH_MAPPED, "{name}", "{genome}"),
         outname   = "{name}_{genome}",
-        threads   = 1,
-        mem       = '64G',
+        threads   = config['execution']['rules']['bam_tag_histogram']['threads'],
+        mem       = config['execution']['rules']['bam_tag_histogram']['memory'],
         java      = SOFTWARE['java']['executable'],
         droptools = SOFTWARE['droptools']['executable'],
         tempdir   = TEMPDIR,
@@ -838,8 +837,8 @@ rule find_absolute_read_cutoff:
     params:
         outdir   = os.path.join(PATH_MAPPED, "{name}", "{genome}"),
         outname  = "{name}_{genome}",
-        threads  = 1,
-        mem      = '8G',
+        threads  = config['execution']['rules']['find_absolute_read_cutoff']['threads'],
+        mem      = config['execution']['rules']['find_absolute_read_cutoff']['memory'],
         cutoff   = 50000,
         script   = PATH_SCRIPT,
         Rscript  = PATH_RSCRIPT
@@ -863,8 +862,8 @@ rule get_umi_matrix:
     params:
         outdir            = os.path.join(PATH_MAPPED, "{name}", "{genome}"),
         outname           = "{name}_{genome}",
-        threads           = 1,
-        mem               = '8G',
+        threads           = config['execution']['rules']['get_umi_matrix']['threads'],
+        mem               = config['execution']['rules']['get_umi_matrix']['memory'],
         java              = SOFTWARE['java']['executable'] ,
         droptools         = SOFTWARE['droptools']['executable'],
         app_name          = 'DigitalExpression',
@@ -910,8 +909,8 @@ rule get_reads_matrix:
         droptools         = SOFTWARE['droptools']['executable'],
         app_name          = 'DigitalExpression',
         tempdir           = TEMPDIR,
-        threads           = 1,
-        mem               = '8G'
+        threads           = config['execution']['rules']['get_reads_matrix']['threads'],
+        mem               = config['execution']['rules']['get_reads_matrix']['memory']
     message: """
             Count UMI:
                 input:  {input.infile}
@@ -946,8 +945,8 @@ rule extract_downstream_statistics:
     params:
         file_location = os.path.join(PATH_MAPPED, "{name}", "{genome}"),
         outname       = "{name}_{genome}",
-        threads       = 1,
-        mem           = '8G',
+        threads       = config['execution']['rules']['extract_downstream_statistics']['threads'],
+        mem           = config['execution']['rules']['extract_downstream_statistics']['memory'],
         script        = PATH_SCRIPT,
         Rscript       = PATH_RSCRIPT
     message: """
@@ -1052,8 +1051,8 @@ rule bam_to_BigWig:
     output:
         bwfile = os.path.join(PATH_MAPPED, "{name}", "{genome}",'{name}_{genome}.bw')
     params:
-        threads = 1,
-        mem     = '16G',
+        threads = config['execution']['rules']['bam_to_BigWig']['threads'],
+        mem     = config['execution']['rules']['bam_to_BigWig']['memory'],
         script  = PATH_SCRIPT,
         Rscript = PATH_RSCRIPT
     message: """
@@ -1073,8 +1072,8 @@ rule fastqc:
         outfile = os.path.join(PATH_MAPPED, "{name}", "{name}.fastqc.done")
     params:
         outpath = os.path.join(PATH_MAPPED, "{name}"),
-        threads = 1,
-        mem     = '16G',
+        threads = config['execution']['rules']['fastqc']['threads'],
+        mem     = config['execution']['rules']['fastqc']['memory'],
         java    = SOFTWARE['java']['executable'],
         fastqc  = SOFTWARE['fastqc']['executable']
     log:

--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -29,6 +29,84 @@ execution:
     __default__:
       threads: 1
       memory: 8G
+    link_primary_annotation:
+      threads: 1
+      memory: 4G
+    combine_reference:
+      threads: 1
+      memory: 4G
+    make_star_reference:
+      threads:  8
+      memory: 40G
+    combine_gtf:
+      threads: 1,
+      memory: 4G
+    fasta_dict:
+      threads:  1
+      memory: 2G
+    change_gtf_id:
+      threads:  1
+      memory: 4G
+    gtf_to_refflat:
+      threads:  1
+      memory: 30G
+    merge_fastq_to_bam:
+      threads:  1
+      memory: 2G
+    tag_cells:
+      threads:  8
+      memory: 35G
+    tag_molecules:
+      threads:  8
+      memory: 35G
+    filter_bam:
+      threads:  1
+      memory: 10G
+    trim_starting_sequence:
+      threads:  1
+      memory: 10G
+    trim_polya:
+      threads:  1
+      memory: 10G
+    sam_to_fastq:
+      threads:  1
+      memory: 10G
+    map_star:
+      threads:  4
+      memory: 32G
+    sort_aligned:
+      threads:  1
+      memory: 5G
+    merge_bam:
+      threads:  1
+      memory: 5G
+    tag_with_gene_exon:
+      threads:  1
+      memory: 5G
+    extract_read_statistics:
+      threads:  1
+      memory: 8G
+    bam_tag_histogram:
+      threads:  1
+      memory: 64G
+    find_absolute_read_cutoff:
+      threads:  1
+      memory: 8G
+    get_umi_matrix:
+      threads:  1
+      memory: 8G
+    get_reads_matrix:
+      threads:  1
+      memory:  8G
+    extract_downstream_statistics:
+      threads:  1
+      memory: 8G
+    bam_to_BigWig:
+      threads:  1
+      memory: 16G
+    fastqc:
+      threads:  1
+      memory: 16G
 
 tools:
   picard:

--- a/etc/settings.yaml.in
+++ b/etc/settings.yaml.in
@@ -21,10 +21,9 @@ execution:
   nice: 19
   cluster:
     missing-file-timeout: 120
-    memory: 8G
     stack: 128M
-    queue: all
     contact-email: none
+    args: ''
   rules:
     __default__:
       threads: 1

--- a/pigx-scrnaseq.in
+++ b/pigx-scrnaseq.in
@@ -107,6 +107,15 @@ parser.add_argument('--unlock', dest='unlock', action='store_true',
                     help="""\
 Recover after a snakemake crash.""")
 
+parser.add_argument('--verbose', dest='verbose', action='store_true',
+                    help="""\
+Print supplementary info on job execution.""")
+
+parser.add_argument('--printshellcmds', dest='printshellcmds', action='store_true',
+                    help="""\
+Print commands being executed by snakemake.""")
+
+
 args = parser.parse_args()
 
 
@@ -180,12 +189,34 @@ def generate_cluster_configuration():
 
     cluster_conf = {}
     for rule in rules:
-        cluster_conf[rule] = {
-            'nthreads': rules[rule]['threads'],
-            'q': config['execution']['cluster']['queue'],
-            'MEM': rules[rule]['memory'],
-            'h_stack': config['execution']['cluster']['stack']
-        }
+        if 'queue' in config['execution']['cluster']:
+            # --- User has supplied general queue name for all rules---
+            if 'queue' in rules[rule]:
+              bail("ERROR: 'queue' multiply defined in settings file.") #AND per rule ->error
+            else:
+              cluster_conf[rule] = {
+              'nthreads': rules[rule]['threads'],
+              'MEM':      rules[rule]['memory'],
+              'queue':    config['execution']['cluster']['queue'],
+              'h_stack':  config['execution']['cluster']['stack']
+              }
+        elif ( 'queue' in rules[rule] ):
+            # --- User has supplied a queue for this specific rule.
+            if not 'queue' in rules['__default__']:
+              bail("ERROR: submission queue specified per rule with no default.")
+            cluster_conf[rule] = {
+              'nthreads': rules[rule]['threads'],
+              'MEM':      rules[rule]['memory'],
+              'queue':    rules[rule]['queue'],
+              'h_stack':  config['execution']['cluster']['stack']
+              }
+        else:
+              # --- User has provided no information on queue for this rule -> default.
+              cluster_conf[rule] = {
+              'nthreads': rules[rule]['threads'],
+              'MEM':      rules[rule]['memory'],
+              'h_stack':  config['execution']['cluster']['stack']
+              }
 
     cluster_config_file = "cluster_conf.json"
     with open(cluster_config_file, 'w') as outfile:
@@ -193,6 +224,7 @@ def generate_cluster_configuration():
                            indent=4, sort_keys=True,
                            separators=(",",": "), ensure_ascii=True)
         outfile.write(dumps)
+
     return cluster_config_file
 
 
@@ -333,6 +365,18 @@ command = [
 if config['execution']['submit-to-cluster']:
     cluster_config_file = generate_cluster_configuration()
     print("Commencing snakemake run submission to cluster", flush=True, file=sys.stderr)
+
+    if ( ('queue' in config['execution']['cluster'] )  or ( 'queue' in config['execution']['rules']['__default__'] )):
+        queue_selection_string = " -q {cluster.queue} "
+	# User has defined queue name(s) --either generally, or rule-specific.
+	# in either case, generate_cluster_configuration() (defined above) has 
+        # already printed the apropriate queue name to each rule.
+        queue_selection_string = " -q {cluster.queue} "
+    else :
+        # User has supplied no q value -> let SGE pick the the default.
+        queue_selection_string = ""
+    # --- done checking if ( queue name(s) supplied by user)
+
     if config['execution']['cluster']['contact-email'].lower() == 'none':
         contact_email_string = ""
     else:
@@ -346,7 +390,7 @@ if config['execution']['submit-to-cluster']:
             exit(1)
         else:
             raise
-    qsub = "qsub -V -l h_stack={cluster.h_stack}  -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % contact_email_string
+    qsub = "qsub -V  %s -l h_stack={cluster.h_stack} -l h_vmem={cluster.MEM} %s -b y -pe smp {cluster.nthreads} -cwd" % ( queue_selection_string, contact_email_string)
     command += [
         "--cluster-config={}".format(cluster_config_file),
         "--cluster={}".format(qsub),
@@ -373,6 +417,10 @@ else:
         command.append("--reason")
     if args.unlock:
         command.append("--unlock")
+    if args.verbose:
+        command.append("--verbose")
+    if args.printshellcmds:
+        command.append("--printshellcmds")
     if args.target == 'help':
         command.append("help")
     subprocess.run(command)

--- a/tests/settings.yaml
+++ b/tests/settings.yaml
@@ -2,6 +2,7 @@ locations:
   output-dir: out/
   reads-dir: sample_data/reads/
   sample-sheet: sample_sheet.csv
+  tempdir:
 
 annotation:
   primary:

--- a/tests/settings.yaml
+++ b/tests/settings.yaml
@@ -9,3 +9,6 @@ annotation:
       name: hg19
       fasta: sample_data/hg19_chr19.10094960.25108012.fa
     gtf: sample_data/hg19_chr19.10094960.25108012.gtf
+
+execution:
+  submit-to-cluster: no


### PR DESCRIPTION
makes the pipeline able to run on the cluster (when `submit-to-cluster` == "yes"). I've just tested it on beast with `submit-to-cluster` set to "no", and run through the necessary debugging steps. 

I've also tested it on dry-runs with `submit-to-cluster : yes` and it passes --this means that at least the syntax input is sensible (and since it's basically the same is in other pipelines, it shouldn't be a problem) 
Note: I tried to ensure that `mem` and `threads` was preserved for all rules (even when it wasn't being sent to the cluster or shell command) in case you used it somewhere else from within params.

Unfortunately, however, there are problems with Java that are preventing an actual run on the cluster, so we haven't done a full test. For the moment, however, it passes all the same tests as the current master, and at least accomplishes dry-run tests on the cluster.