### PR TITLE
Bump snakemake to later version

### DIFF
--- a/scripts/Accessory_Functions.py
+++ b/scripts/Accessory_Functions.py
@@ -66,7 +66,7 @@ def get_adapter_size(name):
 def get_app_params(app_name):
     app_return = subprocess.check_output(SOFTWARE[app_name]['executable'] +' '+ SOFTWARE[app_name]['help'], shell=True)
     app_return = str(app_return)
-    vals = list(set(re.findall('^(\-{1,2}[a-zA-Z][\w\-]*)\W' , app_return)))
+    vals = list(set(re.findall(r'^(\-{1,2}[a-zA-Z][\w\-]*)\W' , app_return)))
     keys = [re.sub('^-+','',i) for i in vals]
     args = dict(zip(keys, vals))
     return(args)
@@ -77,7 +77,7 @@ def get_app_params(app_name):
 def get_star_params():
     app_return = subprocess.check_output(SOFTWARE['STAR']['executable'] +' '+ SOFTWARE['STAR']['help'], shell=True)
     app_return = str(app_return)
-    keys = list(set(re.findall('\\\\n([a-zA-Z]+)\W' , app_return)))
+    keys = list(set(re.findall(r'\\n([a-zA-Z]+)\W' , app_return)))
     vals = ['--' + i for i in keys]
     args = dict(zip(keys, vals))
     return(args)

--- a/scripts/Run_Rscript.py
+++ b/scripts/Run_Rscript.py
@@ -5,6 +5,9 @@ run:
     RunRscript(input, output, params, 'SCRIPT.R')
 """
 
+import json
+import os
+
 def RunRscript(input, output, params, path_script, script):
 
     # if isinstance(input, list):

--- a/snakefile.py
+++ b/snakefile.py
@@ -8,6 +8,7 @@ Snakefile for pigx-scrnaseq pipeline
 import glob
 import os
 import re
+import shutil
 import subprocess
 import yaml
 import csv
@@ -48,7 +49,7 @@ ADAPTER_PARAMETERS = config['adapter_parameters']
 STAR_OUTPUT_TYPES_KEYS = ['Gene', 'GeneFull', 'Velocyto', 'Velocyto']
 STAR_OUTPUT_TYPES_VALS = ['Counts', 'GeneFull', 'Spliced', 'Unspliced']
 # This is a relict variable
-STAR_OUTPUT_TYPES = list(set(STAR_OUTPUT_TYPES_KEYS))
+STAR_OUTPUT_TYPES = sorted(set(STAR_OUTPUT_TYPES_KEYS))
 
 # ----------------------------------------------------------------------------- #
 # PATHS
@@ -641,6 +642,11 @@ rule map_star:
         cb_adapter  = adapter_params(params.name, 'cell_barcode')
         umi_adapter = adapter_params(params.name, 'umi_barcode')
         infiles = " ".join([str(input.reads), str(input.barcode)])
+
+        # STAR aborts if the Solo.out directory from a previous run exists
+        solo_dir = os.path.join(params.outpath, params.name) + '_Solo.out'
+        if os.path.exists(solo_dir):
+            shutil.rmtree(solo_dir)
 
         command = " ".join([
             params.star,


### PR DESCRIPTION
import json explicitly, sort STAR features, clean Solo.out before re-run: - Snakemake 7 executes run: blocks in subprocesses that re-import the snakefile, so json no longer leaks from Snakemake internals and set() ordering varies across processes

Disclaimer: I used help of generative AI to come up with the fix.